### PR TITLE
Update Dockerfile to add protobuf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,7 +156,7 @@ RUN apt-get -y update && \
     
 # Protobuf support
 RUN apt-get -y update && \
-    apt-get -y install --no-install-recommends protobuf-compiler && \
+    apt-get -y install --no-install-recommends python3-distutils protobuf-compiler && \
     wget -q https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     pip3 install protobuf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -153,3 +153,11 @@ RUN apt-get -y update && \
         ninja-build \
         python2 \
     && rm -rf /var/lib/apt/lists/*
+    
+# Protobuf support
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends protobuf-compiler && \
+    wget -q https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    pip3 install protobuf && \
+    rm -rf get-pip.py /var/lib/apt/lists/*


### PR DESCRIPTION
It does not include nanopb, with assumption that it can be used in source code form.